### PR TITLE
fix: filter bot users from assignees when syncing issues

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -171,7 +171,7 @@ const labels: string[] = [...new Set(issue.labels.map(label => label.name).conca
 // If flag for only syncing labelled issues is set, check if issue has label of specified sync type
 const skipSync = ONLY_SYNC_ON_LABEL && !issue.labels.find(label => label.name === ONLY_SYNC_ON_LABEL)
 const sourceIssueAuthor: string = issue.user?.login
-const sourceIssueAssignees: string[] = issue.assignees.map(x => x.login)
+const sourceIssueAssignees: string[] = issue.assignees.filter(x => x.type !== 'Bot').map(x => x.login)
 let targetIssueAssignees: string[] = undefined // if a parameter is undefined, octokit will not use it for API calls when it's passed into a function
 
 console.log(`Found issue ${number}: ${issue.title}`)

--- a/issue.ts
+++ b/issue.ts
@@ -12,6 +12,7 @@ export class Issue {
 
 export class User {
     login: string
+    type?: string
 }
 
 export class IssueComment {


### PR DESCRIPTION
GitHub bot accounts (e.g. Copilot) are not valid assignees in target repos and cause API validation errors. Add `type` field to User and filter out Bot-type users before building the assignees list.