### PR TITLE
fix: make integration test bot-safe and harden issue cleanup

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -60,18 +60,26 @@ SKIP_CLEANUP=1 ./test-integration.sh               # Keep test issues open for d
 
 #### What the Script Does
 
-1. **Creates a real issue** on GitHub with a real human assignee (the authenticated user) and the `integration-test` label
-2. **Fetches the real issue JSON** from the GitHub API (real assignee data, real labels)
-3. **Appends a fake Bot assignee** to the payload — this is the one unavoidable fake, because GitHub's API rejects assigning bots to issues (which is exactly the bug this test validates)
+0. **Sweeps leftover issues** — closes any open issue carrying the `integration-test` / `integration-test-synced` label or the `[integration-test]` title prefix, clearing the backlog from earlier failed runs (skipped when `SKIP_CLEANUP=1`)
+1. **Picks an assignable human** — prefers `GITHUB_ACTOR`, but only if it is a real, assignable user; otherwise falls back to the first assignable user on the repo. This avoids assigning bots (e.g. `renovate[bot]` on dependency PRs), which the installation `GITHUB_TOKEN` cannot assign
+2. **Creates a real issue** with the `integration-test` label (number captured first), then assigns the human in a separate, best-effort step
+3. **Builds a synthetic event payload** by injecting both the chosen human assignee (`type: User`) and a fake Bot assignee (`type: Bot`) — the action reads assignees from the payload (`GITHUB_EVENT_PATH`), so this decouples the test from GitHub-side assignment
 4. **Runs `node dist/index.js`** with `CI=true` and all `INPUT_*` env vars set, simulating the GitHub Actions runtime
 5. **Verifies the real target issue** on GitHub: human assignee preserved, bot assignee filtered out, correct labels applied
-6. **Cleans up** both issues (unless `SKIP_CLEANUP=1`)
+6. **Cleans up** by sweeping every integration-test issue (source, synced target, and any leak), unless `SKIP_CLEANUP=1`
 
 #### Debugging Failures
 
-- Use `SKIP_CLEANUP=1` to keep test issues open for inspection
+- Use `SKIP_CLEANUP=1` to keep test issues open for inspection (also disables the start-of-run sweep)
 - Check the script output for the source/target issue URLs
 - Verify real state with: `gh api repos/OWNER/REPO/issues/NUMBER --jq '{title, assignees: [.assignees[] | {login, type}]}'`
+
+> **Why it failed in CI (May 2026):** Dependency PRs run as `renovate[bot]`, and the
+> script assigned `GITHUB_ACTOR` directly. GitHub's `replaceActorsForAssignable`
+> mutation rejects assigning bots/agents with an installation token, so issue
+> creation failed *after* the issue was already created — leaking an un-cleaned
+> issue on every run. The script now picks an assignable human and always captures
+> the issue number before assigning.
 
 ### Running in CI
 

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -23,8 +23,9 @@ TARGET_ISSUE=""
 EVENT_FILE=""
 
 # Close every open issue that belongs to the integration test, including leaks
-# from earlier failed runs. Matches by label AND by the "[integration-test]" title
-# prefix so nothing slips through even if a label failed to apply.
+# from earlier failed runs. Matches issues carrying the integration-test or
+# integration-test-synced label, OR the "[integration-test]" title prefix, so
+# nothing slips through even if a label failed to apply.
 sweep_integration_issues() {
     local nums num
     nums=$(
@@ -103,12 +104,19 @@ fi
 # Create the source issue first WITHOUT an assignee so the issue number is always
 # captured. If creation and assignment were combined and assignment failed, the
 # issue would still be created but its number lost — leaking an un-cleaned issue.
-SOURCE_ISSUE=$(gh issue create \
+# `gh issue create` prints the issue URL; extract the trailing number with a Bash
+# regex (portable, no PCRE/grep -P which is unavailable on e.g. macOS).
+SOURCE_ISSUE_URL=$(gh issue create \
     --repo "$REPO" \
     --title "[integration-test] $(date +%s)" \
     --body "Automated integration test. Will be cleaned up." \
-    --label "integration-test" \
-    | grep -oP '\d+$')
+    --label "integration-test")
+if [[ "$SOURCE_ISSUE_URL" =~ /([0-9]+)[[:space:]]*$ ]]; then
+    SOURCE_ISSUE="${BASH_REMATCH[1]}"
+else
+    echo "FAIL: Could not parse issue number from create output: ${SOURCE_ISSUE_URL}"
+    exit 1
+fi
 echo "Created source issue #${SOURCE_ISSUE}"
 
 # Assign the human separately (best-effort). The injected payload below is the

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -22,58 +22,120 @@ SOURCE_ISSUE=""
 TARGET_ISSUE=""
 EVENT_FILE=""
 
+# Close every open issue that belongs to the integration test, including leaks
+# from earlier failed runs. Matches by label AND by the "[integration-test]" title
+# prefix so nothing slips through even if a label failed to apply.
+sweep_integration_issues() {
+    local nums num
+    nums=$(
+        {
+            gh issue list --repo "$REPO" --state open --limit 200 \
+                --label "integration-test" --json number --jq '.[].number'
+            gh issue list --repo "$REPO" --state open --limit 200 \
+                --label "integration-test-synced" --json number --jq '.[].number'
+            gh issue list --repo "$REPO" --state open --limit 200 \
+                --search '[integration-test] in:title' --json number --jq '.[].number'
+        } | sort -un
+    )
+    for num in $nums; do
+        gh issue close "$num" --repo "$REPO" --reason "not planned" 2>/dev/null && \
+            echo "Closed #${num}" || echo "Failed to close #${num}"
+    done
+}
+
 cleanup() {
     if [[ -n "$SKIP_CLEANUP" ]]; then
         echo "SKIP_CLEANUP set — leaving issues open"
         [[ -n "$SOURCE_ISSUE" ]] && echo "  Source: https://github.com/${REPO}/issues/${SOURCE_ISSUE}"
         [[ -n "$TARGET_ISSUE" ]] && echo "  Target: https://github.com/${REPO}/issues/${TARGET_ISSUE}"
+        [[ -f "$EVENT_FILE" ]] && rm -f "$EVENT_FILE"
         return
     fi
     echo ""
     echo "=== Cleanup ==="
-    for num in $SOURCE_ISSUE $TARGET_ISSUE; do
-        if [[ -n "$num" ]]; then
-            gh issue close "$num" --repo "$REPO" --reason "not planned" 2>/dev/null && \
-                echo "Closed #${num}" || echo "Failed to close #${num}"
-        fi
-    done
+    # Sweep covers the tracked source/target issues as well as any historical leaks.
+    sweep_integration_issues
     # Remove temp event file
     [[ -f "$EVENT_FILE" ]] && rm -f "$EVENT_FILE"
 }
 trap cleanup EXIT
 
-echo "=== Step 1: Create test issue ==="
-
-# Determine the human user to assign.
-# In GitHub Actions: GITHUB_ACTOR is the user who triggered the workflow (e.g. PR author).
-# Locally: gh api user returns the authenticated user.
-if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
-    CURRENT_USER="${GITHUB_ACTOR:?GITHUB_ACTOR must be set in CI}"
-    echo "Running in GitHub Actions CI — using GITHUB_ACTOR=${CURRENT_USER}"
-else
-    CURRENT_USER=$(gh api user --jq '.login')
-    echo "Running locally — authenticated as ${CURRENT_USER}"
+# Clear any backlog from previously failed runs before starting, so the verify
+# step can unambiguously find the issue created by *this* run.
+if [[ -z "$SKIP_CLEANUP" ]]; then
+    echo "=== Step 0: Sweep leftover integration-test issues ==="
+    sweep_integration_issues
+    echo ""
 fi
 
+echo "=== Step 1: Create test issue ==="
+
+# Determine an *assignable* human user for the test.
+# The action only preserves assignees of type "User"; bots are filtered out.
+# In CI the workflow can be triggered by a bot (e.g. renovate[bot] on dependency
+# PRs). Bots/agents cannot be assigned to issues with the installation
+# GITHUB_TOKEN ("Assigning agents is not supported ... replaceActorsForAssignable"),
+# so never assign GITHUB_ACTOR blindly: verify it is assignable and otherwise fall
+# back to the first assignable user on the repo.
+pick_assignee() {
+    local candidate="${1:-}"
+    if [[ -n "$candidate" && "$candidate" != *"[bot]" ]] \
+        && gh api "repos/${REPO}/assignees/${candidate}" --silent 2>/dev/null; then
+        echo "$candidate"
+        return 0
+    fi
+    gh api "repos/${REPO}/assignees" --jq '.[0].login // empty'
+}
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    ASSIGNEE=$(pick_assignee "${GITHUB_ACTOR:-}")
+    echo "Running in GitHub Actions CI — actor=${GITHUB_ACTOR:-<unset>}, chosen assignee=${ASSIGNEE:-<none>}"
+else
+    ASSIGNEE=$(pick_assignee "$(gh api user --jq '.login')")
+    echo "Running locally — chosen assignee=${ASSIGNEE:-<none>}"
+fi
+
+if [[ -z "$ASSIGNEE" ]]; then
+    echo "FAIL: Could not determine an assignable user for ${REPO}"
+    exit 1
+fi
+
+# Create the source issue first WITHOUT an assignee so the issue number is always
+# captured. If creation and assignment were combined and assignment failed, the
+# issue would still be created but its number lost — leaking an un-cleaned issue.
 SOURCE_ISSUE=$(gh issue create \
     --repo "$REPO" \
     --title "[integration-test] $(date +%s)" \
     --body "Automated integration test. Will be cleaned up." \
     --label "integration-test" \
-    --assignee "$CURRENT_USER" \
     | grep -oP '\d+$')
-echo "Created source issue #${SOURCE_ISSUE} (assigned to ${CURRENT_USER})"
+echo "Created source issue #${SOURCE_ISSUE}"
+
+# Assign the human separately (best-effort). The injected payload below is the
+# source of truth for the action under test, so a GitHub-side assignment failure
+# must not fail or leak the test.
+if gh issue edit "$SOURCE_ISSUE" --repo "$REPO" --add-assignee "$ASSIGNEE" 2>/dev/null; then
+    echo "Assigned ${ASSIGNEE} to source issue #${SOURCE_ISSUE}"
+else
+    echo "WARN: could not assign ${ASSIGNEE} on GitHub — continuing with synthetic payload"
+fi
 
 echo ""
 echo "=== Step 2: Build event payload ==="
 EVENT_FILE=$(mktemp /tmp/issue-sync-test-event.XXXXXX.json)
 
-# Fetch the real issue (which has the human assignee) and inject a Bot assignee
+# Build the event payload from the real issue, then inject a known human assignee
+# and a Bot assignee. The action reads assignees from this payload (GITHUB_EVENT_PATH),
+# so injecting them deterministically decouples the test from GitHub-side assignment
+# (which can be rejected when the workflow actor is a bot).
 gh api "repos/${REPO}/issues/${SOURCE_ISSUE}" | \
-    jq '{
+    jq --arg human "$ASSIGNEE" '{
         action: "labeled",
         issue: (. + {
-            assignees: (.assignees + [{login: "github-actions[bot]", type: "Bot"}])
+            assignees: [
+                {login: $human, type: "User"},
+                {login: "github-actions[bot]", type: "Bot"}
+            ]
         })
     }' > "$EVENT_FILE"
 
@@ -81,11 +143,11 @@ echo "Event file: $EVENT_FILE"
 echo "Assignees in payload:"
 jq -r '.issue.assignees[] | "  \(.login) (type: \(.type // "null"))"' "$EVENT_FILE"
 
-# Sanity check: verify the source issue actually has the human assignee on GitHub
-SOURCE_ASSIGNEES=$(gh api "repos/${REPO}/issues/${SOURCE_ISSUE}" --jq '[.assignees[].login] | join(", ")')
-echo "Actual assignees on source issue #${SOURCE_ISSUE}: ${SOURCE_ASSIGNEES}"
-if [[ -z "$SOURCE_ASSIGNEES" ]]; then
-    echo "FAIL: Source issue has no assignees — test setup is broken"
+# Sanity check: the payload must contain at least one human assignee for the test
+# to be meaningful.
+PAYLOAD_HUMANS=$(jq '[.issue.assignees[] | select(.type == "User")] | length' "$EVENT_FILE")
+if [[ "$PAYLOAD_HUMANS" -eq 0 ]]; then
+    echo "FAIL: Event payload has no human assignee — test setup is broken"
     exit 1
 fi
 
@@ -139,7 +201,7 @@ if [[ "$BOT_ASSIGNEES" -gt 0 ]]; then
 fi
 
 if [[ "$HUMAN_ASSIGNEES" -eq 0 ]]; then
-    echo "FAIL: No human assignees on the target issue — expected ${CURRENT_USER} to be kept!"
+    echo "FAIL: No human assignees on the target issue — expected ${ASSIGNEE} to be kept!"
     exit 1
 fi
 

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -60,9 +60,8 @@ cleanup() {
         echo "SKIP_CLEANUP set — leaving issues open"
         [[ -n "$SOURCE_ISSUE" ]] && echo "  Source: https://github.com/${REPO}/issues/${SOURCE_ISSUE}"
         [[ -n "$TARGET_ISSUE" ]] && echo "  Target: https://github.com/${REPO}/issues/${TARGET_ISSUE}"
-        [[ -f "$EVENT_FILE" ]] && rm -f "$EVENT_FILE"
-        [[ -f "$OUTPUT_FILE" ]] && rm -f "$OUTPUT_FILE"
-        return
+        rm -f "$EVENT_FILE" "$OUTPUT_FILE"
+        return 0
     fi
     echo ""
     echo "=== Cleanup ==="
@@ -73,9 +72,11 @@ cleanup() {
     close_issue "$TARGET_ISSUE"
     # Sweep historical leaks from earlier failed runs.
     sweep_integration_issues
-    # Remove temp files
-    [[ -f "$EVENT_FILE" ]] && rm -f "$EVENT_FILE"
-    [[ -f "$OUTPUT_FILE" ]] && rm -f "$OUTPUT_FILE"
+    # Remove temp files (rm -f tolerates missing/empty paths)
+    rm -f "$EVENT_FILE" "$OUTPUT_FILE"
+    # Return success explicitly: this runs as an EXIT trap, so a non-zero status
+    # from the last command would override a passing run and fail CI.
+    return 0
 }
 trap cleanup EXIT
 

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -21,6 +21,15 @@ SKIP_CLEANUP="${SKIP_CLEANUP:-}"
 SOURCE_ISSUE=""
 TARGET_ISSUE=""
 EVENT_FILE=""
+OUTPUT_FILE=""
+
+# Close a single issue by number (no-op for empty/non-numeric input).
+close_issue() {
+    local num="$1"
+    [[ "$num" =~ ^[0-9]+$ ]] || return 0
+    gh issue close "$num" --repo "$REPO" --reason "not planned" 2>/dev/null && \
+        echo "Closed #${num}" || echo "Failed to close #${num}"
+}
 
 # Close every open issue that belongs to the integration test, including leaks
 # from earlier failed runs. Matches issues carrying the integration-test or
@@ -39,8 +48,10 @@ sweep_integration_issues() {
         } | sort -un
     )
     for num in $nums; do
-        gh issue close "$num" --repo "$REPO" --reason "not planned" 2>/dev/null && \
-            echo "Closed #${num}" || echo "Failed to close #${num}"
+        # Skip issues already handled explicitly by cleanup() to avoid noisy
+        # double-close output (the close above may not be indexed here yet).
+        [[ "$num" == "$SOURCE_ISSUE" || "$num" == "$TARGET_ISSUE" ]] && continue
+        close_issue "$num"
     done
 }
 
@@ -50,14 +61,21 @@ cleanup() {
         [[ -n "$SOURCE_ISSUE" ]] && echo "  Source: https://github.com/${REPO}/issues/${SOURCE_ISSUE}"
         [[ -n "$TARGET_ISSUE" ]] && echo "  Target: https://github.com/${REPO}/issues/${TARGET_ISSUE}"
         [[ -f "$EVENT_FILE" ]] && rm -f "$EVENT_FILE"
+        [[ -f "$OUTPUT_FILE" ]] && rm -f "$OUTPUT_FILE"
         return
     fi
     echo ""
     echo "=== Cleanup ==="
-    # Sweep covers the tracked source/target issues as well as any historical leaks.
+    # Close the issues created by *this* run explicitly. They may not yet appear in
+    # the label/title listing below (GitHub indexing lag), so relying on the sweep
+    # alone would leak the freshly-created source/target issues.
+    close_issue "$SOURCE_ISSUE"
+    close_issue "$TARGET_ISSUE"
+    # Sweep historical leaks from earlier failed runs.
     sweep_integration_issues
-    # Remove temp event file
+    # Remove temp files
     [[ -f "$EVENT_FILE" ]] && rm -f "$EVENT_FILE"
+    [[ -f "$OUTPUT_FILE" ]] && rm -f "$OUTPUT_FILE"
 }
 trap cleanup EXIT
 
@@ -162,9 +180,14 @@ fi
 echo ""
 echo "=== Step 3: Run action ==="
 
+# Capture the action's outputs (issue_id_target) via GITHUB_OUTPUT so we can find
+# the synced issue deterministically, instead of racing GitHub's label indexing.
+OUTPUT_FILE=$(mktemp /tmp/issue-sync-test-output.XXXXXX)
+
 # @actions/core reads inputs from INPUT_* env vars (uppercased, hyphens -> underscores)
 GITHUB_TOKEN=$(gh auth token) \
 CI=true \
+GITHUB_OUTPUT="$OUTPUT_FILE" \
 GITHUB_EVENT_PATH="$EVENT_FILE" \
 GITHUB_EVENT_NAME=issues \
 GITHUB_REPOSITORY="$REPO" \
@@ -187,12 +210,19 @@ INPUT_ISSUE_CREATED_COMMENT_TEMPLATE="" \
 echo ""
 echo "=== Step 4: Verify ==="
 
-# Find the synced issue by the integration-test-synced label
-sleep 2  # give GitHub a moment to index
-TARGET_ISSUE=$(gh issue list --repo "$REPO" --label "integration-test-synced" --state open --json number --jq '.[0].number // empty')
+# Read the synced issue number straight from the action's output. @actions/core
+# writes outputs as multi-line blocks: "issue_id_target<<DELIM\n<value>\nDELIM".
+TARGET_ISSUE=$(
+    awk '
+        /^issue_id_target<</ { getline; print; exit }
+        /^issue_id_target=/ { sub(/^issue_id_target=/, ""); print; exit }
+    ' "$OUTPUT_FILE" | tr -d '[:space:]'
+)
+rm -f "$OUTPUT_FILE"
+OUTPUT_FILE=""
 
 if [[ -z "$TARGET_ISSUE" ]]; then
-    echo "FAIL: No synced issue found with label 'integration-test-synced'"
+    echo "FAIL: action did not emit an issue_id_target output — no synced issue created"
     exit 1
 fi
 echo "Found synced issue #${TARGET_ISSUE}"

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -56,6 +56,11 @@ sweep_integration_issues() {
 }
 
 cleanup() {
+    # Cleanup is best-effort and runs as an EXIT trap. Disable errexit/pipefail
+    # for its duration so a transient `gh`/API error (rate limiting, network)
+    # during the sweep can't abort the trap early and flip a passing run to
+    # failed. The explicit `return 0` at the end keeps the script's exit status.
+    set +e +o pipefail
     if [[ -n "$SKIP_CLEANUP" ]]; then
         echo "SKIP_CLEANUP set — leaving issues open"
         [[ -n "$SOURCE_ISSUE" ]] && echo "  Source: https://github.com/${REPO}/issues/${SOURCE_ISSUE}"


### PR DESCRIPTION
## Description

The integration test has failed on every Renovate dependency PR since **May 9, 2026** ([example run](https://github.com/camunda/issue-sync-action/actions/runs/25596777192/job/75143967969)) and leaked test issues into the repo's issue tracker because they were never cleaned up.

### Root cause

Renovate-triggered runs have `GITHUB_ACTOR=renovate[bot]`, and the script assigned `GITHUB_ACTOR` directly via `gh issue create --assignee`. GitHub's `replaceActorsForAssignable` mutation **rejects assigning bots/agents with an installation `GITHUB_TOKEN`**:

```
GraphQL: Assigning agents is not supported with GitHub App installation tokens.
Use a user token (personal access token or OAuth token) instead. (replaceActorsForAssignable)
```

The failure occurred *inside* the `SOURCE_ISSUE=$(gh issue create ... | grep ...)` command substitution — `gh` created the issue, the assignment failed, and the issue number was never captured. The cleanup trap only closed `$SOURCE_ISSUE`/`$TARGET_ISSUE`, so the orphaned issue leaked on every run (14 `integration-test` + 1 `integration-test-synced` issues had accumulated).

### Changes

- **Bot-safe assignee selection** — `pick_assignee()` uses `GITHUB_ACTOR` only if it is a real, assignable user (checked via `repos/{repo}/assignees/{user}`), otherwise falls back to the first assignable repo user. Bots are never assigned.
- **Always capture the issue number** — the source issue is created without an assignee (so `SOURCE_ISSUE` is captured reliably), then assigned in a separate best-effort step that cannot fail or leak the test.
- **Deterministic payload** — both the human (`type: User`) and bot (`type: Bot`) assignees are injected into the event payload, which is what the action actually reads (`GITHUB_EVENT_PATH`), decoupling the test from GitHub-side assignment.
- **Hardened cleanup** — new `sweep_integration_issues()` closes every open issue matching the `integration-test` / `integration-test-synced` labels **and** the `[integration-test]` title prefix. It runs both at start (Step 0, clearing past backlog) and in the EXIT trap. `SKIP_CLEANUP=1` disables both.
- Updated `TESTING.md`.

### Validation

Ran `./test-integration.sh` locally against `camunda/issue-sync-action`:

- Step 0 swept all 14 leaked issues from previous failed runs.
- Created → synced → verified (human assignee preserved, bot filtered) → **PASS**.
- Cleanup closed the run's issues. **0 open integration-test issues remain.**

Only the shell script and markdown changed — no TypeScript/`dist/` rebuild needed.

## Related issues

n/a

## Checklist

- [x] Tested locally (`./test-integration.sh`)
- [x] No `dist/` changes required (shell + docs only)
